### PR TITLE
New: Added npm support (fixes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Bower Server
+# Adapt plugin registry server
 
 ```sh
-env HEROKU_POSTGRESQL_RED_URL=$(heroku config:get HEROKU_POSTGRESQL_RED_URL -a adapt-bower-repository) ADMIN_REPO=https://github.com/adaptlearning/adapt_framework USER_AGENT=adapt-bower-repository PORT=5000 node index.js
+env HEROKU_POSTGRESQL_RED_URL=$(heroku config:get HEROKU_POSTGRESQL_RED_URL -a adapt-bower-repository) ADMIN_REPO=https://github.com/adaptlearning/adapt_framework USER_AGENT=adapt-bower-repository PORT=5000 GITHUB_TOKEN= node index.js
 ```

--- a/bower.js
+++ b/bower.js
@@ -1,0 +1,104 @@
+
+import { authorize } from './github.js'
+
+export function attachBowerApi (app, packageTable) {
+  // Get all
+  app.get('/packages', async (req, res) => {
+    const packages = await packageTable.all()
+    res.send(packages)
+  })
+
+  // Get named
+  app.get('/packages/:name', async (req, res) => {
+    const { name } = req.params
+    const packageItem = await packageTable.find(name)
+    if (!packageItem) return res.sendStatus(404)
+    await packageItem.hit()
+    res.send(packageItem.toJSON())
+  })
+
+  // Search
+  app.get('/packages/search/:term', async (req, res) => {
+    const { term } = req.params
+    const packages = await packageTable.search(term)
+    res.send(packages)
+  })
+
+  // Register
+  app.post('/packages', async (req, res) => {
+    const { name, url } = req.body
+    console.log(`Registering ${name} ${url}`)
+    const packageItem = packageTable.build({ name, url })
+    try {
+      await packageItem.validate()
+    } catch (validationError) {
+      const firstError = validationError?.errors?.[0]
+      const output = [firstError?.type, firstError?.message, firstError?.value].filter(Boolean).join(', ') || validationError
+      console.error(output)
+      return res.sendStatus(400)
+    }
+    try {
+      await packageItem.register()
+    } catch (err) {
+      console.error(err)
+      return res.sendStatus(406)
+    }
+    res.sendStatus(201)
+  })
+
+  // Rename
+  app.get('/packages/rename/:username/:oldPluginName/:newPluginName', async (req, res) => {
+    const { username, oldPluginName, newPluginName } = req.params
+    const { access_token: token } = req.query
+    console.log(`Renaming ${oldPluginName} to ${newPluginName}`)
+    try {
+      const packageItem = await packageTable.find(oldPluginName)
+      if (!packageItem) return res.sendStatus(404)
+      const { url } = packageItem
+      await authorize({ username, url, token })
+      await packageItem.rename(newPluginName)
+    } catch (err) {
+      console.error('Rename failed', err)
+      return res.sendStatus(500)
+    }
+    res.sendStatus(201)
+  })
+
+  // Unregister
+  app.delete('/packages/:username/:pluginName', async (req, res) => {
+    const { username, pluginName } = req.params
+    const { access_token: token } = req.query
+    console.log(`Unregister ${pluginName}`)
+    try {
+      const packageItem = await packageTable.find(pluginName)
+      if (!packageItem) throw new Error(`${pluginName} not found`)
+      const { url } = packageItem
+      await authorize({ username, url, token })
+      const count = await packageTable.unregister(pluginName)
+      if (count <= 0) return res.sendStatus(404)
+      console.log('Successfully deleted package ' + pluginName)
+    } catch (err) {
+      console.error('Unregister failed with error', err)
+      return res.sendStatus(404)
+    }
+    res.sendStatus(204)
+  })
+
+  // Authentication test
+  app.get('/authenticate/:username/:pluginName', async (req, res) => {
+    const { username, pluginName } = req.params
+    const { access_token: token } = req.query
+    console.log(`Authenticate ${username} for ${pluginName}`)
+    try {
+      const packageItem = await packageTable.find(pluginName)
+      if (!packageItem) throw new Error(`${pluginName} not found`)
+      const { url } = packageItem
+      const type = await authorize({ username, url, token })
+      console.log(`Successfully authenticated ${username} as ${type}`)
+      return res.send({ type })
+    } catch (err) {
+      console.error('Authentication failed with error', err)
+      return res.sendStatus(404)
+    }
+  })
+}

--- a/bower.js
+++ b/bower.js
@@ -1,4 +1,3 @@
-
 import { authorize } from './github.js'
 
 export function attachBowerApi (app, packageTable) {

--- a/constants.js
+++ b/constants.js
@@ -2,8 +2,11 @@ export const ADMIN_REPO = process.env.ADMIN_REPO
 export const USER_AGENT = process.env.USER_AGENT
 export const CONNECTION_STRING = process.env.HEROKU_POSTGRESQL_RED_URL
 export const PORT = process.env.PORT || 5000
+export const GITHUB_TOKEN = process.env.GITHUB_TOKEN
+export const NPM_REGISTRY = process.env.NPM_REGISTRY || 'https://registry.npmjs.org'
 
 console.log(`ADMIN_REPO: ${ADMIN_REPO}`)
 console.log(`USER_AGENT: ${USER_AGENT}`)
 console.log(`CONNECTION_STRING: ${CONNECTION_STRING}`)
 console.log(`PORT: ${PORT}`)
+console.log(`NPM_REGISTRY: ${NPM_REGISTRY}`)

--- a/github.js
+++ b/github.js
@@ -84,22 +84,6 @@ export async function getVersion ({ url, token, version = 'latest' }) {
   return JSON.parse(res.body)
 }
 
-export async function getContents ({ url, token, version = 'latest' }) {
-  if (!isGitHub(url)) throw new Error('getContent passed a non-github url')
-  url = `https://api.github.com/repos/${gh(url).repo}/contents?ref=${version}`
-  let res = await getUrl({ url, token })
-  const code = res.statusCode
-  if (code !== 200 & code !== 204 && code !== 301 && code !== 302 && code !== 307) {
-    throw new Error('getContent error')
-  }
-  // Follow a redirect if necessary
-  if (code === 301 || code === 302 || code === 307) {
-    url = res.headers.location
-    res = await getUrl({ url, token })
-  }
-  return JSON.parse(res.body)
-}
-
 export async function getPackageJSON ({ url, version = 'master' }) {
   const res = await getFirst({
     urls: [

--- a/github.js
+++ b/github.js
@@ -31,13 +31,14 @@ export async function authorize ({
   return 'admin'
 }
 
-async function checkCollaborators ({
+export async function checkCollaborators ({
   username,
   url,
   token
 }) {
+  if (!isGitHub(url)) throw new Error('checkCollaborators passed a non-github url')
   url = 'https://api.github.com/repos/' + gh(url).repo + '/collaborators/' + username
-  const res = await getCollaborators({ url, token })
+  const res = await getUrl({ url, token })
   const code = res.statusCode
   if (code !== 204 && code !== 301 && code !== 302 && code !== 307) {
     throw new Error('checkCollaborators error')
@@ -45,17 +46,99 @@ async function checkCollaborators ({
   // Follow a redirect if necessary
   if (code === 301 || code === 302 || code === 307) {
     url = res.headers.location
-    return await checkCollaborators({ username, url, token })
+    return await getUrl({ username, url, token })
   }
   // GitHub returns 204 if user is collaborator
+  return true
 }
 
-async function getCollaborators ({ url, token }) {
+export async function getVersions ({ url, token }) {
+  if (!isGitHub(url)) throw new Error('getVersions passed a non-github url')
+  url = `https://api.github.com/repos/${gh(url).repo}/releases?per_page=100`
+  let res = await getUrl({ url, token })
+  const code = res.statusCode
+  if (code !== 200 & code !== 204 && code !== 301 && code !== 302 && code !== 307) {
+    throw new Error('getVersions error')
+  }
+  // Follow a redirect if necessary
+  if (code === 301 || code === 302 || code === 307) {
+    url = res.headers.location
+    res = await getUrl({ url, token })
+  }
+  return JSON.parse(res.body)
+}
+
+export async function getVersion ({ url, token, version = 'latest' }) {
+  if (!isGitHub(url)) throw new Error('getVersions passed a non-github url')
+  url = `https://api.github.com/repos/${gh(url).repo}/releases/${version}`
+  let res = await getUrl({ url, token })
+  const code = res.statusCode
+  if (code !== 200 & code !== 204 && code !== 301 && code !== 302 && code !== 307) {
+    throw new Error('getVersions error')
+  }
+  // Follow a redirect if necessary
+  if (code === 301 || code === 302 || code === 307) {
+    url = res.headers.location
+    res = await getUrl({ url, token })
+  }
+  return JSON.parse(res.body)
+}
+
+export async function getContents ({ url, token, version = 'latest' }) {
+  if (!isGitHub(url)) throw new Error('getContent passed a non-github url')
+  url = `https://api.github.com/repos/${gh(url).repo}/contents?ref=${version}`
+  let res = await getUrl({ url, token })
+  const code = res.statusCode
+  if (code !== 200 & code !== 204 && code !== 301 && code !== 302 && code !== 307) {
+    throw new Error('getContent error')
+  }
+  // Follow a redirect if necessary
+  if (code === 301 || code === 302 || code === 307) {
+    url = res.headers.location
+    res = await getUrl({ url, token })
+  }
+  return JSON.parse(res.body)
+}
+
+export async function getPackageJSON ({ url, version = 'master' }) {
+  const res = await getFirst({
+    urls: [
+      `https://raw.githubusercontent.com/${gh(url).repo}/${version}/package.json`,
+      `https://raw.githubusercontent.com/${gh(url).repo}/${version}/bower.json`
+    ]
+  })
+  try {
+    return res && JSON.parse(res.body)
+  } catch (err) {
+    return null
+  }
+}
+
+export async function getFirst ({ urls }) {
+  for (let url of urls) {
+    let res = await getUrl({ url })
+    const code = res.statusCode
+    if (code !== 200 & code !== 204 && code !== 301 && code !== 302 && code !== 307) {
+      continue
+    }
+    // Follow a redirect if necessary
+    if (code === 301 || code === 302 || code === 307) {
+      url = res.headers.location
+      res = await getUrl({ url })
+    }
+    return res
+  }
+  return null
+}
+
+export async function getUrl ({ url, token, method = 'GET' }) {
   return new Promise((resolve, reject) => {
+    const headers = { 'User-Agent': USER_AGENT }
+    if (token) headers.Authorization = 'token ' + token
     request({
       url,
-      method: 'GET',
-      headers: { Authorization: 'token ' + token, 'User-Agent': USER_AGENT },
+      method,
+      headers,
       followRedirect: false
     }, function (err, res) {
       if (err) return reject(err)

--- a/npm.js
+++ b/npm.js
@@ -7,7 +7,7 @@ export async function getRemoteRegistryEntry ({ name, version = '' }) {
   let res = await getUrl({ url })
   const code = res.statusCode
   if (code !== 200 & code !== 204 && code !== 301 && code !== 302 && code !== 307) {
-    throw new Error('getContent error')
+    throw new Error('getRemoteRegistryEntry error')
   }
   // Follow a redirect if necessary
   if (code === 301 || code === 302 || code === 307) {
@@ -54,7 +54,7 @@ export function attachNPMApi (app, packageTable, npmTable) {
   // Get named
   app.get('/npm/:name', async (req, res) => {
     let { name } = req.params
-    if (name.includes('/')) name = name.split('/')[1]
+    if (name.includes('%2f')) name = name.replace('%2f', '/')
     const packageItem = await packageTable.find(name)
     if (!packageItem) {
       const remoteEntry = await getRemoteRegistryEntry({ name })
@@ -116,7 +116,7 @@ export function attachNPMApi (app, packageTable, npmTable) {
   // Get named+versioned
   app.get('/npm/:name/:version', async (req, res) => {
     let { name, version } = req.params
-    if (name.includes('/')) name = name.split('/')[1]
+    if (name.includes('%2f')) name = name.replace('%2f', '/')
     const packageItem = await packageTable.find(name)
     if (!packageItem) {
       const remoteEntry = await getRemoteRegistryEntry({ name, version })

--- a/npm.js
+++ b/npm.js
@@ -70,7 +70,6 @@ export function attachNPMApi (app, packageTable, npmTable) {
       if (npmItem?.data?.version === latestVersionName) {
         return res.send(npmItem.data)
       }
-      // fetch 100 versions + paginate entries, keep full history
       const versions = await getVersions({ url, token: GITHUB_TOKEN })
       const packageJSON = await getPackageJSON({ url })
       const output = {

--- a/npm.js
+++ b/npm.js
@@ -1,0 +1,219 @@
+import gh from 'parse-github-url'
+import { GITHUB_TOKEN, NPM_REGISTRY } from './constants.js'
+import { getVersions, getVersion, getPackageJSON, getUrl } from './github.js'
+
+export async function getRemoteRegistryEntry ({ name, version = '' }) {
+  let url = `${NPM_REGISTRY}/${name}${version ? `/${version}` : ''}`
+  let res = await getUrl({ url })
+  const code = res.statusCode
+  if (code !== 200 & code !== 204 && code !== 301 && code !== 302 && code !== 307) {
+    throw new Error('getContent error')
+  }
+  // Follow a redirect if necessary
+  if (code === 301 || code === 302 || code === 307) {
+    url = res.headers.location
+    res = await getUrl({ url })
+  }
+  return JSON.parse(res.body)
+}
+
+export async function searchRemoteRegistry ({ term }) {
+  let url = `${NPM_REGISTRY}/-/v1/search?text=${term}&size=100`
+  let res = await getUrl({ url })
+  const code = res.statusCode
+  if (code !== 200 & code !== 204 && code !== 301 && code !== 302 && code !== 307) {
+    throw new Error('searchRemoteRegistry error')
+  }
+  // Follow a redirect if necessary
+  if (code === 301 || code === 302 || code === 307) {
+    url = res.headers.location
+    res = await getUrl({ url })
+  }
+  return JSON.parse(res.body)
+}
+
+export function attachNPMApi (app, packageTable, npmTable) {
+  // Get database data
+  app.get('/npm/', async (req, res) => {
+    const packages = await packageTable.all()
+    res.send({
+      db_name: 'registry',
+      doc_count: packages.length,
+      doc_del_count: 0,
+      update_seq: 0,
+      purge_seq: 0,
+      compact_running: false,
+      disk_size: 0,
+      data_size: 0,
+      instance_start_time: 0,
+      disk_format_version: 6,
+      committed_update_seq: 0
+    })
+  })
+
+  // Get named
+  app.get('/npm/:name', async (req, res) => {
+    let { name } = req.params
+    if (name.includes('/')) name = name.split('/')[1]
+    const packageItem = await packageTable.find(name)
+    if (!packageItem) {
+      const remoteEntry = await getRemoteRegistryEntry({ name })
+      if (!remoteEntry) return res.sendStatus(404)
+      return res.send(remoteEntry)
+    }
+    await packageItem.hit()
+    const url = packageItem.url
+    try {
+      const latestVersion = await getVersion({ url, token: GITHUB_TOKEN })
+      const latestVersionName = latestVersion.tag_name.replace(/^v/, '')
+      let npmItem = await npmTable.find(name)
+      if (npmItem?.data?.version === latestVersionName) {
+        return res.send(npmItem.data)
+      }
+      // fetch 100 versions + paginate entries, keep full history
+      const versions = await getVersions({ url, token: GITHUB_TOKEN })
+      const packageJSON = await getPackageJSON({ url })
+      const output = {
+        repository: {
+          type: 'git',
+          url
+        },
+        ...packageJSON || {},
+        'dist-tags': {
+          latest: latestVersionName
+        },
+        modified: latestVersion.published_at,
+        name,
+        versions: versions.reduce((output, version) => {
+          const versionName = version.tag_name.replace(/^v/, '')
+          return {
+            ...output,
+            [versionName]: {
+              _hasShrinkwrap: false,
+              directories: {},
+              dist: {
+                tarball: version.tarball_url
+              },
+              name,
+              version: versionName
+            }
+          }
+        }, {})
+      }
+      for (const version in output.versions) {
+        output.versions[version] = Object.assign({}, (await getPackageJSON({ url, version: `v${version}` })) || {}, output.versions[version])
+      }
+      if (!npmItem) npmItem = npmTable.build({ name, data: output })
+      else npmItem.update(output)
+      npmItem.save()
+      return res.send(output)
+    } catch (err) {
+      console.log(err)
+      return res.sendStatus(404)
+    }
+  })
+
+  // Get named+versioned
+  app.get('/npm/:name/:version', async (req, res) => {
+    let { name, version } = req.params
+    if (name.includes('/')) name = name.split('/')[1]
+    const packageItem = await packageTable.find(name)
+    if (!packageItem) {
+      const remoteEntry = await getRemoteRegistryEntry({ name, version })
+      if (!remoteEntry) return res.sendStatus(404)
+      return res.send(remoteEntry)
+    }
+    await packageItem.hit()
+    const url = packageItem.url
+    try {
+      const latestVersion = await getVersion({ url, token: GITHUB_TOKEN })
+      const latestVersionName = latestVersion.tag_name.replace(/^v/, '')
+      if (version === 'latest') version = latestVersionName
+      let npmItem = await npmTable.find(name)
+      if (npmItem?.data?.version === latestVersionName) {
+        if (!npmItem.data.versions[version]) return res.sendStatus(404)
+        return res.send(npmItem.data.versions[version])
+      }
+      const versions = await getVersions({ url, token: GITHUB_TOKEN })
+      const packageJSON = await getPackageJSON({ url })
+      const output = {
+        repository: {
+          type: 'git',
+          url
+        },
+        ...packageJSON || {},
+        'dist-tags': {
+          latest: latestVersionName
+        },
+        modified: latestVersion.published_at,
+        name,
+        versions: versions.reduce((output, version) => {
+          const versionName = version.tag_name.replace(/^v/, '')
+          return {
+            ...output,
+            [versionName]: {
+              _hasShrinkwrap: false,
+              directories: {},
+              dist: {
+                tarball: version.tarball_url
+              },
+              name,
+              version: versionName
+            }
+          }
+        }, {})
+      }
+      for (const version in output.versions) {
+        output.versions[version] = Object.assign({}, (await getPackageJSON({ url, version: `v${version}` })) || {}, output.versions[version])
+      }
+      if (!npmItem) npmItem = npmTable.build({ name, data: output })
+      else npmItem.update(output)
+      npmItem.save()
+      if (!npmItem.data.versions[version]) return res.sendStatus(404)
+      return res.send(npmItem.data.versions[version])
+    } catch (err) {
+      console.log(err)
+      return res.sendStatus(404)
+    }
+  })
+
+  // Search
+  app.get('/npm/-/v1/search/', async (req, res) => {
+    let {
+      text = '', // string full-text search to apply
+      size = 20, // integer how many results should be returned (default 20, max 250)
+      from = 0 // integer offset to return results from
+      // TODO: implement the below
+      // quality, // float (0-1) how much of an effect should quality have on search results
+      // popularity, // float (0-1) how much of an effect should popularity have on search results
+      // maintenance // float (0-1) how much of an effect should maintenance have on search results
+    } = req.query
+    size = Math.max(Math.min(250, size), 0)
+    const npmItems = await npmTable.search(text)
+    const remote = await searchRemoteRegistry(text)
+    const localNames = npmItems.map((npmItem) => npmItem.name.toLowerCase());
+    const remoteObjects = remote.objects.filter(obj => obj.name && !localNames.includes(obj.name.toLowerCase()))
+    const localObjects = npmItems.map(npmItem => {
+      const author = gh(npmItem.data.repository?.url.replace('git:', 'https:'))?.owner
+      const maintainers = author ? [{ username: author }] : null
+      return {
+        package: { date: npmItem.data.modified, maintainers, ...npmItem.data },
+        score: {
+          final: 1,
+          defailt: {
+            quality: 1,
+            popularity: 1,
+            maintenance: 1
+          }
+        }
+      }
+    })
+
+    const unfilteredObjects = localObjects.concat(remoteObjects)
+    res.send({
+      objects: unfilteredObjects.slice(from, size),
+      total: unfilteredObjects.length,
+      time: 'Wed Jan 25 2017 19:23:35 GMT+0000 (UTC)'
+    })
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bower-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -506,6 +506,40 @@
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
+      }
+    },
+    "compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "concat-map": {
@@ -1995,6 +2029,11 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "bower-server",
-  "description": "Node port of the bower server",
-  "version": "0.2.0",
+  "name": "adapt-registry-server",
+  "description": "Adapt plugin registry server",
+  "version": "0.3.0",
   "type": "module",
   "dependencies": {
+    "compression": "^1.7.4",
     "express": "^4.17.2",
     "parse-github-url": "^1.0.2",
     "pg": "^8.7.1",

--- a/webserver.js
+++ b/webserver.js
@@ -1,115 +1,31 @@
 import express from 'express'
-import { getPackageTable } from './database.js'
-import { authorize } from './github.js'
+import compression from 'compression'
+import { getNPMTable, getPackageTable } from './database.js'
 import { PORT } from './constants.js'
+import { attachBowerApi } from './bower.js'
+import { attachNPMApi } from './npm.js'
 
 export async function start ({
   port = PORT
 } = {}) {
   const packageTable = await getPackageTable()
+  const npmTable = await getNPMTable()
   const app = express()
+  app.use(compression({
+    filter: function shouldCompress (req, res) {
+      if (req.headers['x-no-compression']) {
+        // don't compress responses with this request header
+        return false
+      }
+      // fallback to standard filter function
+      return compression.filter(req, res)
+    }
+  }))
   app.use(express.json())
   app.use(express.urlencoded({ extended: true }))
 
-  // Get all
-  app.get('/packages', async (req, res) => {
-    const packages = await packageTable.all()
-    res.send(packages)
-  })
-
-  // Get named
-  app.get('/packages/:name', async (req, res) => {
-    const { name } = req.params
-    const packageItem = await packageTable.find(name)
-    if (!packageItem) return res.send(404)
-    await packageItem.hit()
-    res.send(packageItem.toJSON())
-  })
-
-  // Search
-  app.get('/packages/search/:term', async (req, res) => {
-    const { term } = req.params
-    const packages = await packageTable.search(term)
-    res.send(packages)
-  })
-
-  // Register
-  app.post('/packages', async (req, res) => {
-    const { name, url } = req.body
-    console.log(`Registering ${name} ${url}`)
-    const packageItem = packageTable.build({ name, url })
-    try {
-      await packageItem.validate()
-    } catch (validationError) {
-      const firstError = validationError?.errors?.[0]
-      const output = [firstError?.type, firstError?.message, firstError?.value].filter(Boolean).join(', ') || validationError
-      console.error(output)
-      return res.sendStatus(400)
-    }
-    try {
-      await packageItem.register()
-    } catch (err) {
-      console.error(err)
-      return res.sendStatus(406)
-    }
-    res.sendStatus(201)
-  })
-
-  // Rename
-  app.get('/packages/rename/:username/:oldPluginName/:newPluginName', async (req, res) => {
-    const { username, oldPluginName, newPluginName } = req.params
-    const { access_token: token } = req.query
-    console.log(`Renaming ${oldPluginName} to ${newPluginName}`)
-    try {
-      const packageItem = await packageTable.find(oldPluginName)
-      if (!packageItem) return res.sendStatus(404)
-      const { url } = packageItem
-      await authorize({ username, url, token })
-      await packageItem.rename(newPluginName)
-    } catch (err) {
-      console.error('Rename failed', err)
-      return res.sendStatus(500)
-    }
-    res.sendStatus(201)
-  })
-
-  // Unregister
-  app.delete('/packages/:username/:pluginName', async (req, res) => {
-    const { username, pluginName } = req.params
-    const { access_token: token } = req.query
-    console.log(`Unregister ${pluginName}`)
-    try {
-      const packageItem = await packageTable.find(pluginName)
-      if (!packageItem) throw new Error(`${pluginName} not found`)
-      const { url } = packageItem
-      await authorize({ username, url, token })
-      const count = await packageTable.unregister(pluginName)
-      if (count <= 0) return res.sendStatus(404)
-      console.log('Successfully deleted package ' + pluginName)
-    } catch (err) {
-      console.error('Unregister failed with error', err)
-      return res.sendStatus(404)
-    }
-    res.sendStatus(204)
-  })
-
-  // Authentication test
-  app.get('/authenticate/:username/:pluginName', async (req, res) => {
-    const { username, pluginName } = req.params
-    const { access_token: token } = req.query
-    console.log(`Authenticate ${username} for ${pluginName}`)
-    try {
-      const packageItem = await packageTable.find(pluginName)
-      if (!packageItem) throw new Error(`${pluginName} not found`)
-      const { url } = packageItem
-      const type = await authorize({ username, url, token })
-      console.log(`Successfully authenticated ${username} as ${type}`)
-      return res.send({ type })
-    } catch (err) {
-      console.error('Authentication failed with error', err)
-      return res.sendStatus(404)
-    }
-  })
+  attachBowerApi(app, packageTable)
+  attachNPMApi(app, packageTable, npmTable)
 
   app.listen(port)
 }


### PR DESCRIPTION
fixes #5 

### New
* Added `/npm/` [API](https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md) for npm client
  * Cache npm api results for registered plugins and update on new releases when requested
  * Added `GITHUB_TOKEN` parameter to authenticate the server with github for releases and package.json downloads
  * Pass-through to default npm registry https://registry.npmjs.org/

### Fixed
* Searches are now done with case insensitivity
* Renamed to reflect server behaviour